### PR TITLE
Fix regather other parties not triggering

### DIFF
--- a/docassemble/Simpmotion/data/questions/simpmotion.yml
+++ b/docassemble/Simpmotion/data/questions/simpmotion.yml
@@ -195,18 +195,31 @@ code: |
     
   nav.set_section('review_download')
   # is it necessary to call these so that their value can be accessed when filling form?
-  plaintiffs
-  defendants
-  plaintiffs_attorney
-  defendants_attorney
+  #  plaintiffs
+  #  defendants
+  #  plaintiffs_attorney
+  #  defendants_attorney
   interview_order_simpmotion = True
 ---
 only sets: add_or_remove_users
 code: |
   if len(users.complete_elements()) > 1 and not multiple_users:
     users.remove(users[1])
+    if defined('user_side_lawyer'):
+      del user_side_lawyer
+    if defined('defendants_attorney'):
+      del defendants_attorney
+    if defined('plaintiffs_attorney'):
+      del plaintiffs_attorney
   elif len(users.elements) == 1 and multiple_users and not user_first_party:
     users.appendObject()
+  if user_first_party:
+    if defined('user_side_lawyer'):
+      del user_side_lawyer
+    if defined('defendants_attorney'):
+      del defendants_attorney
+    if defined('plaintiffs_attorney'):
+      del plaintiffs_attorney
   if not multiple_users or user_first_party:
     users[0].address.address
     users[0].phone_number

--- a/docassemble/Simpmotion/data/questions/simpmotion.yml
+++ b/docassemble/Simpmotion/data/questions/simpmotion.yml
@@ -1208,7 +1208,8 @@ code: |
     other_parties.target_number = 1
     if showifdef('other_parties.gathered') and len(other_parties) == 0:
       del other_parties.gathered
-      del other_parties.there_are_any
+      if defined('other_parties.there_are_any'):
+        del other_parties.there_are_any
       if defined('other_party_lawyer'):
         del other_party_lawyer
   if len(other_parties.complete_elements()) > 0:

--- a/docassemble/Simpmotion/data/questions/simpmotion.yml
+++ b/docassemble/Simpmotion/data/questions/simpmotion.yml
@@ -1025,7 +1025,7 @@ review:
       <strong>
       % if len(other_parties.complete_elements()) > 0:
       The ${ other_side_label }: ${ other_parties }
-      % else:
+      % elif user_started_case:
       There is not a defendant or respondent in your case.
       % endif
       </strong>
@@ -1172,6 +1172,7 @@ subquestion: |
   % endif
 continue button field: other_parties.revisit
 ---
+if: user_started_case
 generic object: ALPeopleList
 table: x.table
 rows: x
@@ -1180,6 +1181,17 @@ columns:
       row_item.name if defined('row_item.name.first') else ''
 edit:
   - name.first
+---
+if: not user_started_case
+generic object: ALPeopleList
+table: x.table
+rows: x
+columns:
+  - Name: |
+      row_item.name if defined('row_item.name.first') else ''
+edit:
+  - name.first
+delete buttons: False
 ---
 table: users.table
 rows: users
@@ -1196,7 +1208,9 @@ code: |
     other_parties.target_number = 1
     if showifdef('other_parties.gathered') and len(other_parties) == 0:
       del other_parties.gathered
-      del other_party_lawyer
+      del other_parties.there_are_any
+      if defined('other_party_lawyer'):
+        del other_party_lawyer
   if len(other_parties.complete_elements()) > 0:
     if other_side_has_lawyer and not other_party_lawyer:
       del other_party_lawyer


### PR DESCRIPTION
Need to delete both `gathered` and `there_are_any` to get the regathering to properly trigger.

Also fixed:

* don't let user delete other party if user is defendant (needs a plaintiff)
* Don't show "There is not a defendant or respondent in your case" if user is the defendant, just show blank

Fix #33.